### PR TITLE
Recursive Issue in MultiBlockBase.cs

### DIFF
--- a/Block/MultiBlockBase.cs
+++ b/Block/MultiBlockBase.cs
@@ -86,9 +86,22 @@ namespace StoneQuarry
 
         public BlockSounds GetSounds(IBlockAccessor blockAccessor, BlockSelection blockSel, ItemStack stack, Vec3i offset)
         {
+            if (blockSel == null) return null;
             BlockSelection coreBlockSel = blockSel.Clone();
             coreBlockSel.Position += offset.AsBlockPos;
-            return GetSounds(blockAccessor, coreBlockSel, stack, offset);
+            if (offset == Vec3i.Zero)
+            {
+                return base.GetSounds(blockAccessor, coreBlockSel, stack);
+            }
+            try
+            {
+                return base.GetSounds(blockAccessor, coreBlockSel, stack);
+            }
+            catch (Exception ex)
+            {
+                api.Logger.Error("Error in GetSounds: {0}", ex);
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
This will fix the problem causing the game/server to freeze and client to crash when the player is "near" or rather when the player collides with a BlockStoneSlab and/or RubbleStorage etc.

This was a recursive issue, causing an infinite loop for GetSounds.